### PR TITLE
Add function to convert from js string to vec<u8>

### DIFF
--- a/src/val.rs
+++ b/src/val.rs
@@ -435,6 +435,15 @@ impl Val {
         }
     }
 
+    pub fn as_bytes(&self) -> Vec<u8> {
+        unsafe {
+            let ptr = _emval_as_str(self.handle);
+            let ret = CStr::from_ptr(ptr).to_bytes().to_vec();
+            free(ptr as _);
+            ret
+        }
+    }
+
     /// Convert a javascript Array to a Rust Vec
     pub fn to_vec<T: JsType>(&self) -> Vec<T> {
         let len = self.get(&"length").as_::<u32>();


### PR DESCRIPTION
Implement `as_bytes`, a function that converts a `Val` to a `Vec<u8>`.
As Javascript string can contain any byte sequence, we need a `Vec<u8>` type to represent them.