### PR TITLE
Draft: support buffer containing null-terminators and non-utf8 characters

### DIFF
--- a/src/externs.rs
+++ b/src/externs.rs
@@ -2,6 +2,7 @@ use crate::{val::Val, val::EM_VAL};
 
 extern "C" {
     pub fn _emval_as_str(v: EM_VAL) -> *mut i8;
+    pub fn _emval_as_bytes(v: EM_VAL, output_buffer: *mut u8) -> u64;
     pub fn _emval_add_event_listener(v: EM_VAL, f: *const i8, data: *mut ());
     pub fn _emval_take_fn(argcount: u8, data: *const ()) -> EM_VAL;
     pub fn free(ptr: *const ());

--- a/src/val.rs
+++ b/src/val.rs
@@ -437,10 +437,10 @@ impl Val {
 
     pub fn as_bytes(&self) -> Vec<u8> {
         unsafe {
-            let ptr = _emval_as_str(self.handle);
-            let ret = CStr::from_ptr(ptr).to_bytes().to_vec();
-            free(ptr as _);
-            ret
+            let len = _emval_as_bytes(self.handle, std::ptr::null_mut()) as usize;
+            let mut output_buffer: Vec<u8> = vec![0; len];
+            let _ = _emval_as_bytes(self.handle, output_buffer.as_mut_ptr());
+            output_buffer
         }
     }
 


### PR DESCRIPTION
I realized there are multiple issues with #3 .

First, if the data contains null bytes, it will be cut off.
Also, while JavaScript strings can have any byte in them and are well represented using `Vec<u8>`, a lot of JavaScript functions producing strings decode the string while assuming `utf8`.

For example `fetch().text()` decodes the data and breaks it.

My first thought is to first get the length of the data to be able to allocate a buffer for it, but this is not very efficient.

For the second point, I need to be able to decode JavaScript [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) objects for which I need to dig a bit into the emval code.

I don't have a lot of time right now, but I'm opening this so that I have a GitHub notification and remember to do it as some point.